### PR TITLE
Accepted file can also be Blob

### DIFF
--- a/PromiseFileReader.js
+++ b/PromiseFileReader.js
@@ -1,5 +1,5 @@
 function readAsDataURL(file) {
-  if (!(file instanceof File || file instanceof Blob)) {
+  if (!(file instanceof Blob)) {
     throw new TypeError('Must be a File or Blob')
   }
   return new Promise((resolve, reject) => {
@@ -11,7 +11,7 @@ function readAsDataURL(file) {
 }
 
 function readAsText(file) {
-  if (!(file instanceof File || file instanceof Blob)) {
+  if (!(file instanceof Blob)) {
     throw new TypeError('Must be a File or Blob')
   }
   return new Promise((resolve, reject) => {
@@ -23,7 +23,7 @@ function readAsText(file) {
 }
 
 function readAsArrayBuffer(file) {
-  if (!(file instanceof File || file instanceof Blob)) {
+  if (!(file instanceof Blob)) {
     throw new TypeError('Must be a File or Blob')
   }
   return new Promise((resolve, reject) => {

--- a/PromiseFileReader.js
+++ b/PromiseFileReader.js
@@ -1,6 +1,6 @@
 function readAsDataURL(file) {
-  if (!(file instanceof File)) {
-    throw new TypeError('Must be a File')
+  if (!(file instanceof File || file instanceof Blob)) {
+    throw new TypeError('Must be a File or Blob')
   }
   return new Promise((resolve, reject) => {
     const reader = new FileReader()
@@ -11,8 +11,8 @@ function readAsDataURL(file) {
 }
 
 function readAsText(file) {
-  if (!(file instanceof File)) {
-    throw new TypeError('Must be a File')
+  if (!(file instanceof File || file instanceof Blob)) {
+    throw new TypeError('Must be a File or Blob')
   }
   return new Promise((resolve, reject) => {
     const reader = new FileReader()
@@ -23,8 +23,8 @@ function readAsText(file) {
 }
 
 function readAsArrayBuffer(file) {
-  if (!(file instanceof File)) {
-    throw new TypeError('Must be a File')
+  if (!(file instanceof File || file instanceof Blob)) {
+    throw new TypeError('Must be a File or Blob')
   }
   return new Promise((resolve, reject) => {
     const reader = new FileReader()


### PR DESCRIPTION
According to the specification https://developer.mozilla.org/en-US/docs/Web/API/FileReader a FileReader can read objects of the type File or Blob.

This PR adds the ability to also read in Blobs.

I ran into a Problem using the library where i needed to read in a blob but the methods only accept File objects. First I thought I could create a file like `new File([myblob], "filename")` but that way the mimetype info gets lost and when i call `readAsDataUrl()` i get a string but without the proper mimetype it's useless. This PR fixes all of that by allowing Blobs as well.
