### PR TITLE
Downgrade to ES5

### DIFF
--- a/PromiseFileReader.js
+++ b/PromiseFileReader.js
@@ -2,10 +2,10 @@ function readAs (file, as) {
   if (!(file instanceof Blob)) {
     throw new TypeError('Must be a File or Blob')
   }
-  return new Promise((resolve, reject) => {
+  return new Promise(function(resolve, reject) {
     const reader = new FileReader()
-    reader.onload = e => resolve(e.target.result)
-    reader.onerror = e => reject(`Error reading ${file.name}: ${e.target.result}`)
+    reader.onload = function(e) { resolve(e.target.result) }
+    reader.onerror = function(e) { reject(`Error reading ${file.name}: ${e.target.result}`) }
     reader['readAs' + as](file)
   })
 }


### PR DESCRIPTION
Closes: https://github.com/jahredhope/promise-file-reader/issues/4

@kachkaev raised the issue that currently this package doesn't babel to ES5 before publishing.
Rather than adding babel I've just manually downgraded the code.

Would this solve for your case @kachkaev?