### PR TITLE
refactor: downgrade to ES5

### DIFF
--- a/PromiseFileReader.js
+++ b/PromiseFileReader.js
@@ -2,10 +2,10 @@ function readAs (file, as) {
   if (!(file instanceof Blob)) {
     throw new TypeError('Must be a File or Blob')
   }
-  return new Promise((resolve, reject) => {
+  return new Promise(function(resolve, reject) {
     const reader = new FileReader()
-    reader.onload = e => resolve(e.target.result)
-    reader.onerror = e => reject(`Error reading ${file.name}: ${e.target.result}`)
+    reader.onload = function(e) { resolve(e.target.result) }
+    reader.onerror = function(e) { reject('Error reading' + file.name + ': ' + e.target.result) }
     reader['readAs' + as](file)
   })
 }
@@ -22,4 +22,8 @@ function readAsArrayBuffer (file) {
   return readAs(file, 'ArrayBuffer')
 }
 
-module.exports = { readAsDataURL, readAsText, readAsArrayBuffer }
+module.exports = {
+  readAsDataURL: readAsDataURL,
+  readAsText: readAsText,
+  readAsArrayBuffer: readAsArrayBuffer,
+}


### PR DESCRIPTION
Makes this module compatible with create-react-app, which does not apply babel to node_modules.

Closes #4, see also #5.