### PR TITLE
Change from const to var

### DIFF
--- a/PromiseFileReader.js
+++ b/PromiseFileReader.js
@@ -3,7 +3,7 @@ function readAs (file, as) {
     throw new TypeError('Must be a File or Blob')
   }
   return new Promise(function(resolve, reject) {
-    const reader = new FileReader()
+    var reader = new FileReader()
     reader.onload = function(e) { resolve(e.target.result) }
     reader.onerror = function(e) { reject(new Error('Error reading' + file.name + ': ' + e.target.result)) }
     reader['readAs' + as](file)


### PR DESCRIPTION
Using the library with Chromium 40 which does not support the const keyword in strict mode but does support Promise. Saw a previous pull request to make the library more es5 compatible so this seems like the right direction.